### PR TITLE
Add documentation of TYPES collector

### DIFF
--- a/lib/Pod/Weaver/PluginBundle/FLORA.pm
+++ b/lib/Pod/Weaver/PluginBundle/FLORA.pm
@@ -48,6 +48,9 @@ This plugin bundle is equivalent to the following weaver.ini file:
 
   [Collect / FUNCTIONS]
   command = func
+  
+  [Collect / TYPES]
+  command = type
 
   [Leftovers]
 


### PR DESCRIPTION
I was wondering why I was getting different pod out when I dropped the use of your weaver bundle... turns out the docs don't match what you actually do :)
