### PR TITLE
change PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,4 +10,3 @@ repository_at = github
 
 [Prereq]
 Pod::Elemental::Transformer::List = 0
-Pod::Weaver::Plugin::Encoding = 0

--- a/lib/Pod/Weaver/PluginBundle/FLORA.pm
+++ b/lib/Pod/Weaver/PluginBundle/FLORA.pm
@@ -62,7 +62,7 @@ This plugin bundle is equivalent to the following weaver.ini file:
   [-Transformer]
   transformer = List
 
-  [-Encoding]
+  [-SingleEncoding]
 
 =begin Pod::Coverage
 
@@ -95,7 +95,8 @@ sub mvp_bundle_config {
         [ '@FLORA/Legal',     _exp('Legal'),        {} ],
 
         [ '@FLORA/List',      _exp('-Transformer'), { transformer => 'List' } ],
-        [ '@FLORA/Encoding',  _exp('-Encoding'),    {} ],
+
+        [ '@FLORA/SingleEncoding', _exp('-SingleEncoding'), {} ],
     );
 }
 


### PR DESCRIPTION
Hi,

`Pod::Weaver` now has`SingleEncoding` plugin (starting from 4.000), which makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
